### PR TITLE
CustomPlaylistGroups have a level count

### DIFF
--- a/PlaylistCore/Overrides/CustomPlaylistBackButton.cs
+++ b/PlaylistCore/Overrides/CustomPlaylistBackButton.cs
@@ -18,6 +18,6 @@ namespace PlaylistCore.Overrides
 
         public Sprite coverImage => Utilities.backButton;
 
-        public IBeatmapLevelCollection beatmapLevelCollection => new BeatmapLevelCollection(new DummyPreviewBeatmapLevel[0]);
+        public IBeatmapLevelCollection beatmapLevelCollection => new DummyBeatmapLevelCollection();
     }
 }


### PR DESCRIPTION
* CustomPlaylistsGroups show the song count of their manager (not including child managers, but you can change that by making the `false` `true` @ `manager.GetAllPlaylists(false, out _)`).
* Also change the collectionName because I'm pretty sure it would create a new DirectoryInfo every time the get was called.